### PR TITLE
29 change precision in tests

### DIFF
--- a/tests/testthat/test-calculate_predictions_recalibrated_type_1.R
+++ b/tests/testthat/test-calculate_predictions_recalibrated_type_1.R
@@ -143,6 +143,16 @@ test_that("Calculates the type 1 recalibrated predictions properly for logreg mo
     calculate_predictions(data) |>
     calculate_predictions_recalibrated_type_1(data)
 
-  expect_identical(model$predictions_recal_type_1, readRDS(test_path("fixtures", "logreg", "predictions_recal_type_1_logreg.rds")))
-  expect_identical(model$alpha_type_1, readRDS(test_path("fixtures", "logreg", "alpha_type_1_logreg.rds")))
+  expect_identical(
+    sapply(model$predictions_recal_type_1, round, digits = 7),
+    sapply(
+      readRDS(test_path("fixtures", "logreg", "predictions_recal_type_1_logreg.rds")),
+      round,
+      digits = 7
+    )
+  )
+  expect_identical(
+    round(model$alpha_type_1, 7),
+    round(readRDS(test_path("fixtures", "logreg", "alpha_type_1_logreg.rds")), 7)
+  )
 })

--- a/tests/testthat/test-calculate_predictions_recalibrated_type_2.R
+++ b/tests/testthat/test-calculate_predictions_recalibrated_type_2.R
@@ -144,8 +144,19 @@ test_that("Calculates the type 2 recalibrated predictions properly for logreg mo
     calculate_predictions(data) |>
     calculate_predictions_recalibrated_type_2(data)
 
-  expect_identical(model$predictions_recal_type_2, readRDS(test_path("fixtures", "logreg", "predictions_recal_type_2_logreg.rds")))
-  expect_identical(model$alpha_type_2, readRDS(test_path("fixtures", "logreg", "alpha_type_2_logreg.rds")))
-  expect_identical(model$beta_overall, readRDS(test_path("fixtures", "logreg", "beta_overall_logreg.rds")))
+  expect_identical(
+    sapply(model$predictions_recal_type_2, round, digits = 7),
+    sapply(
+      readRDS(test_path("fixtures", "logreg", "predictions_recal_type_2_logreg.rds")),
+      round,
+      digits = 7
+    )
+  )
+  expect_identical(
+    round(model$alpha_type_2, 7),
+    round(readRDS(test_path("fixtures", "logreg", "alpha_type_2_logreg.rds")), 7)
+  )
+  expect_identical(
+    round(model$beta_overall, 7), round(readRDS(test_path("fixtures", "logreg", "beta_overall_logreg.rds")), 7)
+  )
 })
-

--- a/tests/testthat/test-get_calibration_plot.R
+++ b/tests/testthat/test-get_calibration_plot.R
@@ -175,7 +175,18 @@ test_that("The calibration plot data function works properly with type 'predicti
   expect_no_error(get_calibration_plot_data(model, data, 2, "predictions_aggregated"))
   expect_no_error(get_calibration_plot_data(model, data, 2, "predictions_recal_type_1"))
   expect_error(get_calibration_plot_data(model, data, 2, "predictions_recal_type_2"))
-  expect_identical(get_calibration_plot_data(model, data, 2, "predictions_recal_type_1"), readRDS(test_path("fixtures", "logreg", "calibration_plot_data_2_groups_recal_1_logreg.rds")))
+  expect_identical(
+    sapply(
+      get_calibration_plot_data(model, data, 2, "predictions_recal_type_1"),
+      round,
+      digits = 7
+    ),
+    sapply(
+      readRDS(test_path("fixtures", "logreg", "calibration_plot_data_2_groups_recal_1_logreg.rds")),
+      round,
+      digits = 7
+    )
+  )
 })
 
 test_that("The calibration plot data function works properly with type 'predictions_recal_type_2' cox", {
@@ -203,7 +214,18 @@ test_that("The calibration plot data function works properly with type 'predicti
   expect_no_error(get_calibration_plot_data(model, data, 2, "predictions_aggregated"))
   expect_no_error(get_calibration_plot_data(model, data, 2, "predictions_recal_type_2"))
   expect_error(get_calibration_plot_data(model, data, 2, "predictions_recal_type_1"))
-  expect_identical(get_calibration_plot_data(model, data, 2, "predictions_recal_type_2"), readRDS(test_path("fixtures", "logreg", "calibration_plot_data_2_groups_recal_2_logreg.rds")))
+  expect_identical(
+    sapply(
+      get_calibration_plot_data(model, data, 2, "predictions_recal_type_2"),
+      round,
+      digits = 7
+    ),
+    sapply(
+      readRDS(test_path("fixtures", "logreg", "calibration_plot_data_2_groups_recal_2_logreg.rds")),
+      round,
+      digits = 7
+    )
+  )
 })
 
 test_that("The calibration plot data checks the 'data' parameter", {


### PR DESCRIPTION
The precision in numeric tests is changed to 7 digits due to R precision while computing. The following files were changed

* `tests-get_calibration_plot.R`
* `tests-calculate_predictions_recalibrated_type_1.R`
* `tests-calculate_predictions_recalibrated_type_2.r`