### PR TITLE
27 improve errors messages in calculate predictions

### DIFF
--- a/MiceExtVal.Rproj
+++ b/MiceExtVal.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: e7182b1b-60f4-4c57-9c8e-7572dcbbc6b2
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/MiceExtVal.Rproj
+++ b/MiceExtVal.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 19c98189-b4ba-4938-a049-88c268fa202b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/R/calculate_c_index.R
+++ b/R/calculate_c_index.R
@@ -50,40 +50,33 @@ calculate_c_index <- function(model, data, .progress = FALSE) {
   error_message <- NULL
 
   if (!methods::is(model, "MiceExtVal")) {
-    error_message <- c(error_message, cli::format_error("{.arg model} must be of type `MiceExtVal`"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg model} must be {.cls MiceExtVal}"))
   }
   if (!methods::is(data, "data.frame")) {
-    error_message <- c(error_message, cli::format_error("{.arg data} must be of type `data.frame`"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg data} must be {.cls data.frame}"))
   } else {
     if (!".imp" %in% colnames(data)) {
-      error_message <- c(error_message, cli::format_error("{.arg data} must contain {.arg .imp}"))
+      error_message <- c(error_message, "*" = cli::format_error("{.arg data} must contain {.arg .imp}"))
     }
 
     if (!"predictions_data" %in% names(model)) {
-      error_message <- c(error_message, cli::format_error("{.arg model} must contain {.arg predictions_data} calculate it with {.fun MiceExtval::calculate_predictions}"))
+      error_message <- c(error_message, "*" = cli::format_error("{.arg model} must contain {.arg predictions_data} calculate it with {.fun MiceExtval::calculate_predictions}"))
     }
 
     if (!"formula" %in% names(model)) {
-      error_message <- c(error_message, cli::format_error("{.arg model} must contain a valid {.arg formula}"))
+      error_message <- c(error_message, "*" = cli::format_error("{.arg model} must contain a valid {.arg formula}"))
     } else {
       dependent_variable <- all.vars(model$formula)[1]
       if (!dependent_variable %in% colnames(data)) {
-        error_message <-  c(error_message, cli::format_error("the dependent variable must be part of {.arg data}"))
+        error_message <-  c(error_message, "*" = cli::format_error("the dependent variable {.var {dependent_variable}} must be part of {.arg data}"))
       }
       if (!methods::is(data[[dependent_variable]], "Surv")) {
-        error_message <- c(error_message, cli::format_error("the dependent variable must be of class {.arg Surv}"))
+        error_message <- c(error_message, "*" = cli::format_error("the dependent variable {.var {dependent_variable}} must be {.cls Surv}"))
       }
     }
   }
 
-  if (!is.null(error_message)) {
-    names(error_message) <- rep("*", length(error_message))
-    cli::cli_abort(error_message)
-  }
-
-  # Returns an error if the dependent variable in the model formula does not exist
-  # in `data` or is not a survival class
-
+  if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Code for the progress bar
   if (.progress) {

--- a/R/calculate_predictions.cox.R
+++ b/R/calculate_predictions.cox.R
@@ -44,27 +44,8 @@
 #'   z = rnorm(9, 2, 0.75)
 #' )
 calculate_predictions.cox <- function(model, data) {
-  error_message <- NULL
-  if (is.null(model$coefficients) | !all(names(model$coefficients) %in% colnames(data))) {
-    error_message <- c(error_message, cli::format_error("all the model coefficients must be present in {.arg data}"))
-  }
-
-  if (is.null(model$means) | !all(names(model$means) %in% colnames(data))) {
-    error_message <- c(error_message, cli::format_error("all the means variables must be present in {.arg data}"))
-  }
-
-  if (!".imp" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} must contain {.arg .imp}"))
-  }
-
-  if (!"id" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} must contain {.arg id}"))
-  }
-
-  if (!is.null(error_message)) {
-    names(error_message) <- rep("*", length(error_message))
-    cli::cli_abort(error_message)
-  }
+  error_message <- MiceExtVal:::get_error_message_calculate(model, data)
+  if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Obtain the expression that calculates the `betax` from the `coefficients` and `mean` paramters. Loop over all the variable names and generates the expression `(coef * (var - mean))`
   variables <- sapply(

--- a/R/calculate_predictions_recalibrated_type_1.cox.R
+++ b/R/calculate_predictions_recalibrated_type_1.cox.R
@@ -50,43 +50,8 @@
 #'   calculate_predictions(data) |>
 #'   calculate_predictions_recalibrated_type_1(data)
 calculate_predictions_recalibrated_type_1.cox <- function(model, data, .progress = FALSE) {
-  error_message <- NULL
-
-
-  # Returns an error if `.imp` is not part of the `data` parameter
-  if (!".imp" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg .imp}"))
-  }
-
-  # Returns an error if `id` is not part of the `data` parameter
-  if (!"id" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg id}"))
-  }
-
-  # Returns an error if `predictions_data` does not exist in `model`
-  if (!"predictions_data" %in% names(model) | !methods::is(model$predictions_data, "data.frame")) {
-    error_message <- c(error_message, cli::format_error("{.arg model} must have {.arg predictions_data} calculated"))
-  }
-
-  # Returns an error if the dependent variable in the model formula does not exist
-  # in `data` or is not a survival class
-  dependent_variable <- all.vars(model$formula)[1]
-  if (!dependent_variable %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be part of {.arg data}"))
-  }
-  if (!methods::is(data[[dependent_variable]], "Surv")) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be of class {.arg Surv}"))
-  }
-
-  # Returns an error if `S0` does not exist or it is bad defined in the cox model
-  if (is.null(model$S0) | !is.numeric(model$S0)) {
-    error_message <- c(error_message, cli::format_error("{.arg S0} must be a {.arg numeric}"))
-  }
-
-  if (!is.null(error_message)) {
-    names(error_message) <- rep("*", length(error_message))
-    cli::cli_abort(error_message)
-  }
+  error_message <- MiceExtVal:::get_error_message_calculate_type_1(model, data)
+  if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Progress bar code
   if (.progress) {

--- a/R/calculate_predictions_recalibrated_type_1.cox.R
+++ b/R/calculate_predictions_recalibrated_type_1.cox.R
@@ -50,7 +50,7 @@
 #'   calculate_predictions(data) |>
 #'   calculate_predictions_recalibrated_type_1(data)
 calculate_predictions_recalibrated_type_1.cox <- function(model, data, .progress = FALSE) {
-  error_message <- MiceExtVal:::get_error_message_calculate_type_1(model, data)
+  error_message <- MiceExtVal:::get_error_message_calculate_recalibrated(model, data)
   if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Progress bar code

--- a/R/calculate_predictions_recalibrated_type_1.logreg.R
+++ b/R/calculate_predictions_recalibrated_type_1.logreg.R
@@ -57,41 +57,8 @@
 #'   calculate_predictions(data) |>
 #'   calculate_predictions_recalibrated_type_1(data)
 calculate_predictions_recalibrated_type_1.logreg <- function(model, data, .progress = FALSE) {
-  error_message <- NULL
-  # Returns an error if `.imp` is not part of the `data` parameter
-  if (!".imp" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg .imp}"))
-  }
-
-  # Returns an error if `id` is not part of the `data` parameter
-  if (!"id" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg id}"))
-  }
-
-  # Returns an error if `predictions_data` does not exist in `model`
-  if (!"predictions_data" %in% names(model) | !methods::is(model$predictions_data, "data.frame")) {
-    error_message <- c(error_message, cli::format_error("{.arg model} must have {.arg predictions_data} calculated"))
-  }
-
-  # Returns an error if the dependent variable in the model formula does not exist
-  # in `data` or is not a survival class
-  dependent_variable <- all.vars(model$formula)[1]
-  if (!dependent_variable %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be part of {.arg data}"))
-  }
-  if (!methods::is(data[[dependent_variable]], "Surv")) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be of class {.arg Surv}"))
-  }
-
-  # Returns an error if `intercept` does not exist or it is bad defined
-  if (is.null(model$intercept) | !is.numeric(model$intercept)) {
-    error_message <- c(error_message, cli::format_error("{.arg intercept} must be a {.arg numeric}"))
-  }
-
-  if (!is.null(error_message)) {
-    names(error_message) <- rep("*", length(error_message))
-    cli::cli_abort(error_message)
-  }
+  error_message <- MiceExtVal:::get_error_message_calculate_type_1(model, data)
+  if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Progress bar code
   if (.progress) {

--- a/R/calculate_predictions_recalibrated_type_1.logreg.R
+++ b/R/calculate_predictions_recalibrated_type_1.logreg.R
@@ -57,7 +57,7 @@
 #'   calculate_predictions(data) |>
 #'   calculate_predictions_recalibrated_type_1(data)
 calculate_predictions_recalibrated_type_1.logreg <- function(model, data, .progress = FALSE) {
-  error_message <- MiceExtVal:::get_error_message_calculate_type_1(model, data)
+  error_message <- MiceExtVal:::get_error_message_calculate_recalibrated(model, data)
   if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Progress bar code

--- a/R/calculate_predictions_recalibrated_type_2.cox.R
+++ b/R/calculate_predictions_recalibrated_type_2.cox.R
@@ -58,41 +58,8 @@
 #'   calculate_predictions_recalibrated_type_1(data) |>
 #'   calculate_predictions_recalibrated_type_2(data)
 calculate_predictions_recalibrated_type_2.cox <- function(model, data, .progress = FALSE) {
-  error_message <- NULL
-  # Returns an error if `.imp` is not part of the `data` parameter
-  if (!".imp" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg .imp}"))
-  }
-
-  # Returns an error if `id` is not part of the `data` parameter
-  if (!"id" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg id}"))
-  }
-
-  # Returns an error if `predictions_data` does not exist in `model`
-  if (!"predictions_data" %in% names(model) | !methods::is(model$predictions_data, "data.frame")) {
-    error_message <- c(error_message, cli::format_error("{.arg model} must have {.arg predictions_data} calculated"))
-  }
-
-  # Returns an error if the dependent variable in the model formula does not exist
-  # in `data` or is not a survival class
-  dependent_variable <- all.vars(model$formula)[1]
-  if (!dependent_variable %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be part of {.arg data}"))
-  }
-  if (!methods::is(data[[dependent_variable]], "Surv")) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be of class {.arg Surv}"))
-  }
-
-  # Returns an error if `S0` does not exist or it is bad defined in the cox model
-  if (is.null(model$S0) | !is.numeric(model$S0)) {
-    error_message <- c(error_message, cli::format_error("{.arg S0} must be a {.arg numeric}"))
-  }
-
-  if (!is.null(error_message)) {
-    names(error_message) <- rep("*", length(error_message))
-    cli::cli_abort(error_message)
-  }
+  error_message <- MiceExtVal:::get_error_message_calculate_recalibrated(model, data)
+  if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Progress bar code
   if (.progress) {

--- a/R/calculate_predictions_recalibrated_type_2.logreg.R
+++ b/R/calculate_predictions_recalibrated_type_2.logreg.R
@@ -59,42 +59,8 @@
 #'   calculate_predictions_recalibrated_type_1(data) |>
 #'   calculate_predictions_recalibrated_type_2(data)
 calculate_predictions_recalibrated_type_2.logreg <- function(model, data, .progress = FALSE) {
-  error_message <- NULL
-
-  # Returns an error if `.imp` is not part of the `data` parameter
-  if (!".imp" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg .imp}"))
-  }
-
-  # Returns an error if `id` is not part of the `data` parameter
-  if (!"id" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg id}"))
-  }
-
-  # Returns an error if `predictions_data` does not exist in `model`
-  if (!"predictions_data" %in% names(model) | !methods::is(model$predictions_data, "data.frame")) {
-    error_message <- c(error_message, cli::format_error("{.arg model} must have {.arg predictions_data} calculated"))
-  }
-
-  # Returns an error if the dependent variable in the model formula does not exist
-  # in `data` or is not a survival class
-  dependent_variable <- all.vars(model$formula)[1]
-  if (!dependent_variable %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be part of {.arg data}"))
-  }
-  if (!methods::is(data[[dependent_variable]], "Surv")) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be of class {.arg Surv}"))
-  }
-
-  # Returns an error if `intercept` does not exist or it is bad defined
-  if (is.null(model$intercept) | !is.numeric(model$intercept)) {
-    error_message <- c(error_message, cli::format_error("{.arg intercept} must be a {.arg numeric}"))
-  }
-
-  if (!is.null(error_message)) {
-    names(error_message) <- rep("*", length(error_message))
-    cli::cli_abort(error_message)
-  }
+  error_message <- MiceExtVal:::get_error_message_calculate_recalibrated(model, data)
+  if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # Progress bar code
   if (.progress) {

--- a/R/get_c_index_forestplot.R
+++ b/R/get_c_index_forestplot.R
@@ -37,7 +37,7 @@ get_c_index_forestplot <- function(...) {
   model_names <- purrr::map2_chr(model_names_callname, model_names_call, ~ ifelse(is.na(.x) | .x == "", .y, .x))
 
   if (!all(is_model_class)) {
-    cli::cli_abort("The model{?s} {.arg {model_names[!is_model_class]}} must be from the class {.arg MiceExtVal}")
+    cli::cli_abort("The model{?s} {.arg {model_names[!is_model_class]}} must be {.cls MiceExtVal}")
   }
 
   has_c_index <- purrr::map_lgl(list(...), \(x) !is.null(x$c_index))

--- a/R/get_calibration_plot_data.R
+++ b/R/get_calibration_plot_data.R
@@ -32,45 +32,42 @@
 get_calibration_plot_data <- function(model, data, n_groups, type = "predictions_aggregated") {
   error_message <- NULL
   if (!methods::is(model, "MiceExtVal")) {
-    error_message <- c(error_message, cli::format_error("{.arg model} must be of class {.arg MiceExtVal}"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg model} must be {.cls MiceExtVal}"))
   }
   if (!methods::is(data, "data.frame")) {
-    error_message <- c(error_message, cli::format_error("{.arg data} must be of class {.arg data.frame}"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg data} must be {.cls data.frame}"))
   } else {
 
   }
   if (!methods::is(n_groups, "numeric")) {
-    error_message <- c(error_message, cli::format_error("{.arg n_groups} must be of class {.arg numeric}"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg n_groups} must be {.cls numeric}"))
   }
 
   if (!any(type %in% c("predictions_aggregated", "predictions_recal_type_1", "predictions_recal_type_2"))) {
-    error_message <- c(error_message, cli::format_error("{.arg type} must be one of the following types: {.arg {c('predictions_aggregated', 'predictions_recal_type_1', 'predictions_recal_type_2')}}"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg type} must be one of the following types: {.arg {c('predictions_aggregated', 'predictions_recal_type_1', 'predictions_recal_type_2')}}"))
   }
 
   # Returns an error if `.imp` is not part of the `data` parameter
   if (!".imp" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg .imp}"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg data} variable must contain {.arg .imp}"))
   }
 
   # Returns an error if `id` is not part of the `data` parameter
   if (!"id" %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("{.arg data} variable must contain {.arg id}"))
+    error_message <- c(error_message, "*" = cli::format_error("{.arg data} variable must contain {.arg id}"))
   }
 
   # Returns an error if the dependent variable in the model formula does not exist
   # in `data` or is not a survival class
   dependent_variable <- all.vars(model$formula)[1]
   if (!dependent_variable %in% colnames(data)) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be part of {.arg data}"))
+    error_message <- c(error_message, "*" = cli::format_error("the dependent variable {.var {dependent_variable}} must be part of {.arg data}"))
   }
   if (!methods::is(data[[dependent_variable]], "Surv")) {
-    error_message <- c(error_message, cli::format_error("the dependent variable must be of class {.arg Surv}"))
+    error_message <- c(error_message, "*" = cli::format_error("the dependent variable {.var {dependent_variable}} must be {.cls Surv}"))
   }
 
-  if (!is.null(error_message)) {
-    names(error_message) <- rep("*", length(error_message))
-    cli::cli_abort(error_message)
-  }
+  if (!is.null(error_message)) cli::cli_abort(error_message)
 
   # We assume that the observed variable is completed and therefore the same in
   # all the imputed datasets. If not we should generate the aggregated result

--- a/R/get_error_message_calculate.R
+++ b/R/get_error_message_calculate.R
@@ -1,0 +1,51 @@
+#' Logic for checkin all the needed parameters for `calculate_` functions are
+#' correct
+#'
+#' @param data
+#' @param model
+#'
+#' @return `NULL` if no errors were found or the actual error if some errors
+#' were found.
+get_error_message_calculate <- function(model, data) {
+  error_message <- NULL
+
+  # check that the coefficients variables are in the `data` argument
+  if (is.null(model$coefficients)) {
+    error_message <- c(error_message, cli::format_error(""))
+  }
+
+  if (!is.null(model$coefficients) & !all(names(model$coefficients) %in% colnames(data))) {
+    coef_not_in_data <- names(model$coefficients) %in% colnames(data)
+    coefs <- names(model$coefficients)[coef_not_in_data]
+    error_message <- c(error_message, "*" = cli::format_error("The {.strong model coefficient{?s}} {.var {coefs}} must be present in {.arg data}"))
+  }
+
+  # check that the means variables are in the `data` argument
+  if (methods::is(model, "cox") & is.null(model$means)) {
+    error_message <- c(error_message, cli::format_error(""))
+  }
+
+  if (methods::is(model, "cox") & !is.null(model$means) & !all(names(model$means) %in% colnames(data))) {
+    mean_not_in_data <- names(model$means) %in% colnames(data)
+    means <- names(model$means)[mean_not_in_data]
+    error_message <- c(error_message, "*" = cli::format_error("The {.strong model mean{?s}} {.var {means}} must be present in {.arg data}"))
+  }
+
+
+  # check that the dataset is multiple imputed and contains an id
+  if (!".imp" %in% colnames(data)) {
+    error_message <- c(error_message, "*" = cli::format_error("The variable {.var .imp} (number of imputation each row is part of) must be present in {.arg data}"))
+  }
+
+  if (!"id" %in% colnames(data)) {
+    error_message <- c(error_message, "*" = cli::format_error("The variable {.var id} (unique identifier for each row) must be present in {.arg data}"))
+  }
+
+  # if `model` is a logreg, check for its intercept
+  if (methods::is(model, "logreg") &
+    (!"intercept" %in% names(model) | !methods::is(model$intercept, "numeric"))) {
+    error_message <- c(error_message, "*" = "The {.strong model intercept} must be {.cls numeric} (check if exists)")
+  }
+
+  return(error_message)
+}

--- a/R/get_error_message_calculate_recalibrated.R
+++ b/R/get_error_message_calculate_recalibrated.R
@@ -1,10 +1,10 @@
-#' generates the error messages for the `calculate_predictions_recalibrated_type_1`
+#' generates the error messages for the recalibrated predictions
 #'
 #' @param model
 #' @param data
 #'
 #' @returns the error message for the given model and data
-get_error_message_calculate_type_1 <- function(model, data) {
+get_error_message_calculate_recalibrated <- function(model, data) {
   error_message <- NULL
   # check that the dataset is multiple imputed and contains an id
   if (!".imp" %in% colnames(data)) {

--- a/R/get_error_message_calculate_type_1.R
+++ b/R/get_error_message_calculate_type_1.R
@@ -1,0 +1,47 @@
+#' generates the error messages for the `calculate_predictions_recalibrated_type_1`
+#'
+#' @param model
+#' @param data
+#'
+#' @returns the error message for the given model and data
+get_error_message_calculate_type_1 <- function(model, data) {
+  error_message <- NULL
+  # check that the dataset is multiple imputed and contains an id
+  if (!".imp" %in% colnames(data)) {
+    error_message <- c(error_message, "*" = cli::format_error("The variable {.var .imp} (number of imputation each row is part of) must be present in {.arg data}"))
+  }
+
+  if (!"id" %in% colnames(data)) {
+    error_message <- c(error_message, "*" = cli::format_error("The variable {.var id} (unique identifier for each row) must be present in {.arg data}"))
+  }
+
+  # Returns an error if `predictions_data` does not exist in `model`
+  if (!"predictions_data" %in% names(model) | !methods::is(model$predictions_data, "data.frame")) {
+    error_message <- c(error_message, "*" = cli::format_error("In {.arg model} there should be the argument {.arg predictions_data} {.cls tibble} calculated (see {.fn MiceExtVal::calculate_predictions})"))
+  }
+
+  # Returns an error if the dependent variable in the model formula does not exist
+  # in `data` or is not a survival class
+  dependent_variable <- all.vars(model$formula)[1]
+  if (!dependent_variable %in% colnames(data)) {
+    error_message <- c(error_message, "*" = cli::format_error("The dependent variable {.var {dependent_variable}} must be part of {.arg data}"))
+  }
+  if (!methods::is(data[[dependent_variable]], "Surv")) {
+    error_message <- c(error_message, "*" = cli::format_error("The dependent variable {.var {dependent_variable}} must be {.cls Surv}"))
+  }
+
+  if (methods::is(model, "cox")) {
+    # Returns an error if `S0` does not exist or it is bad defined in the cox model
+    if (is.null(model$S0) | !is.numeric(model$S0)) {
+      error_message <- c(error_message, "*" = cli::format_error("{.arg S0} must be {.cls numeric}"))
+    }
+  }
+
+  if (methods::is(model, "logreg")) {
+    if (is.null(model$intercept) | !is.numeric(model$intercept)) {
+      error_message <- c(error_message, "*" = cli::format_error("{.arg intercept} must be {.cls numeric}"))
+    }
+  }
+
+  return(error_message)
+}

--- a/tests/testthat/test-calculate_c_index.R
+++ b/tests/testthat/test-calculate_c_index.R
@@ -78,15 +78,15 @@ test_that("Returns an error if the dependent variable in the model formula does 
 
   model_cox_bad_dependent_variable <- model_cox
   model_cox_bad_dependent_variable$formula <- y ~ x + z
-  expect_error(calculate_c_index(model_cox_bad_dependent_variable, data), "the dependent variable must be of class `Surv`")
+  expect_error(calculate_c_index(model_cox_bad_dependent_variable, data), "the dependent variable `y` must be <Surv>")
   model_cox_bad_dependent_variable$formula <- no_exists ~ x + z
-  expect_error(calculate_c_index(model_cox_bad_dependent_variable, data), "the dependent variable must be part of `data`")
+  expect_error(calculate_c_index(model_cox_bad_dependent_variable, data), "the dependent variable `no_exists` must be part of `data`")
 
   model_logreg_bad_dependent_variable <- model_logreg
   model_logreg_bad_dependent_variable$formula <- y ~ x + z
-  expect_error(calculate_c_index(model_logreg_bad_dependent_variable, data), "the dependent variable must be of class `Surv`")
+  expect_error(calculate_c_index(model_logreg_bad_dependent_variable, data), "the dependent variable `y` must be <Surv>")
   model_logreg_bad_dependent_variable$formula <- no_exists ~ x + z
-  expect_error(calculate_c_index(model_logreg_bad_dependent_variable, data), "the dependent variable must be part of `data`")
+  expect_error(calculate_c_index(model_logreg_bad_dependent_variable, data), "the dependent variable `no_exists` must be part of `data`")
 })
 
 test_that("Calculates the c-index properly for a cox model", {

--- a/tests/testthat/test-calculate_predictions.R
+++ b/tests/testthat/test-calculate_predictions.R
@@ -26,7 +26,7 @@ test_that("Returns an error if `.imp` is not part of the `data` parameter", {
   model <- make_cox_model(environment())
   data_no_imp <- data |> select(-.imp)
 
-  expect_error(model |> calculate_predictions(data_no_imp), "must contain `.imp`")
+  expect_error(model |> calculate_predictions(data_no_imp), "The variable `.imp`")
 })
 
 test_that("Returns an error if `id` is not part of the `data` parameter", {
@@ -34,7 +34,7 @@ test_that("Returns an error if `id` is not part of the `data` parameter", {
   model <- make_cox_model(environment())
   data_no_id <- data |> select(-id)
 
-  expect_error(model |> calculate_predictions(data_no_id), "must contain `id`")
+  expect_error(model |> calculate_predictions(data_no_id), "The variable `id`")
 })
 
 test_that("Returns an error if model `coefficients` names are inside the `data` parameter", {
@@ -42,7 +42,7 @@ test_that("Returns an error if model `coefficients` names are inside the `data` 
   model <- make_cox_model(environment())
 
   model$coefficients <- append(list(m = 0.875), model$coefficients)
-  expect_error(model |> calculate_predictions(data), "all the model coefficients must be present in `data`")
+  expect_error(model |> calculate_predictions(data), "The model coefficients `x` and `z` must be present in `data`")
 })
 
 test_that("Returns an error if model `means` names are inside the `data` parameter", {
@@ -50,7 +50,7 @@ test_that("Returns an error if model `means` names are inside the `data` paramet
   model <- make_cox_model(environment())
 
   model$means <- append(list(m = 4), model$means)
-  expect_error(model |> calculate_predictions(data), "all the means variables must be present in `data`")
+  expect_error(model |> calculate_predictions(data), "The model means `x` and `z` must be present in `data`")
 })
 
 test_that("Calculates the predictions properly in Cox model", {
@@ -72,7 +72,7 @@ test_that("Returns an error if `.imp` is not part of the `data` parameter", {
   model <- make_logreg_model(environment())
   data_no_imp <- data %>% select(-.imp)
 
-  expect_error(model |> calculate_predictions(data_no_imp), "must contain `.imp`")
+  expect_error(model |> calculate_predictions(data_no_imp), "The variable `.imp`")
 })
 
 test_that("Returns an error if `id` is not part of the `data` parameter", {
@@ -80,7 +80,7 @@ test_that("Returns an error if `id` is not part of the `data` parameter", {
   model <- make_logreg_model(environment())
   data_no_id <- data %>% select(-id)
 
-  expect_error(model |> calculate_predictions(data_no_id), "must contain `id`")
+  expect_error(model |> calculate_predictions(data_no_id), "The variable `id`")
 })
 
 test_that("Returns an error if model `coefficients` names are not in the `data` parameter", {
@@ -89,7 +89,7 @@ test_that("Returns an error if model `coefficients` names are not in the `data` 
 
   model$coefficients <- append(list(m = 0.875), model$coefficients)
 
-  expect_error(model |> calculate_predictions(data), "all the model coefficients must be present in `data`")
+  expect_error(model |> calculate_predictions(data), "The model coefficients `x` and `z` must be present in `data`")
 })
 
 test_that("Returns an error if model `intercept` does not exist", {
@@ -98,10 +98,10 @@ test_that("Returns an error if model `intercept` does not exist", {
 
   model$intercept <- NULL
 
-  expect_error(model |> calculate_predictions(data), "model `intercept` must be `numeric`")
+  expect_error(model |> calculate_predictions(data), "The model intercept must be <numeric>")
 
   model$intercept <- "a"
-  expect_error(model |> calculate_predictions(data), "model `intercept` must be `numeric`")
+  expect_error(model |> calculate_predictions(data), "The model intercept must be <numeric>")
 })
 
 test_that("Calculates the predictions properly in logreg model", {
@@ -116,3 +116,4 @@ test_that("Calculates the predictions properly in logreg model", {
   expect_identical(model$betax, readRDS(test_path("fixtures", "logreg", "betax_logreg.rds")))
   expect_identical(model$betax_data, readRDS(test_path("fixtures", "logreg", "betax_data_logreg.rds")))
 })
+

--- a/tests/testthat/test-calculate_predictions_recalibrated_type_1.R
+++ b/tests/testthat/test-calculate_predictions_recalibrated_type_1.R
@@ -22,7 +22,7 @@ test_that("Returns an error if `.imp` is not part of the `data` parameter", {
   model <- make_cox_model(environment()) |> calculate_predictions(data)
   data_no_imp <- data |> select(-.imp)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_imp), "must contain `.imp`")
+  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_imp), "The variable `.imp`")
 })
 
 test_that("Returns an error if `id` is not part of the `data` parameter", {
@@ -30,7 +30,7 @@ test_that("Returns an error if `id` is not part of the `data` parameter", {
   model <- make_cox_model(environment()) |> calculate_predictions(data)
   data_no_id <- data |> select(-id)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_id), "must contain `id`")
+  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_id), "The variable `id`")
 })
 
 
@@ -41,7 +41,7 @@ test_that("Returns an error if `predictions_data` does not exist in cox `model`"
 
   model_cox_no_predictions_data <- model_cox
   model_cox_no_predictions_data$predictions_data <- NULL
-  expect_error(calculate_predictions_recalibrated_type_1(model_cox_no_predictions_data, data), "`model` must have `predictions_data` calculated")
+  expect_error(calculate_predictions_recalibrated_type_1(model_cox_no_predictions_data, data), "In `model` there should be the argument `predictions_data` <tibble> calculated")
 })
 
 test_that("Returns an error if the dependent variable in the cox model formula does not exist in `data` or is not a survival class", {
@@ -51,9 +51,9 @@ test_that("Returns an error if the dependent variable in the cox model formula d
 
   model_cox_bad_dependent_variable <- model_cox
   model_cox_bad_dependent_variable$formula <- y ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_dependent_variable, data), "the dependent variable must be of class `Surv`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_dependent_variable, data), "The dependent variable `y` must be <Surv>")
   model_cox_bad_dependent_variable$formula <- no_exists ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_dependent_variable, data), "the dependent variable must be part of `data`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_dependent_variable, data), "The dependent variable `no_exists` must be part of `data`")
 })
 
 test_that("Returns an error if `S0` does not exist or it is bad defined in the cox model", {
@@ -63,9 +63,9 @@ test_that("Returns an error if `S0` does not exist or it is bad defined in the c
 
   model_cox_bad_s0 <- model_cox
   model_cox_bad_s0$S0 <- NULL
-  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_s0, data), "`S0` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_s0, data), "`S0` must be <numeric>")
   model_cox_bad_s0$S0 <- "a"
-  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_s0, data), "`S0` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_cox_bad_s0, data), "`S0` must be <numeric>")
 })
 
 test_that("Calculates the type 1 recalibrated predictions properly for cox model", {
@@ -92,7 +92,7 @@ test_that("Returns an error if `.imp` is not part of the `data` parameter", {
   model <- make_logreg_model(environment()) |> calculate_predictions(data)
   data_no_imp <- data |> select(-.imp)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_imp), "must contain `.imp`")
+  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_imp), "The variable `.imp`")
 })
 
 test_that("Returns an error if `id` is not part of the `data` parameter", {
@@ -100,7 +100,7 @@ test_that("Returns an error if `id` is not part of the `data` parameter", {
   model <- make_logreg_model(environment()) |> calculate_predictions(data)
   data_no_id <- data |> select(-id)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_id), "must contain `id`")
+  expect_error(model |> calculate_predictions_recalibrated_type_1(data_no_id), "The variable `id`")
 })
 
 test_that("Returns an error if `predictions_data` does not exist in logreg `model`", {
@@ -110,7 +110,7 @@ test_that("Returns an error if `predictions_data` does not exist in logreg `mode
 
   model_logreg_no_predictions_data <- model_logreg
   model_logreg_no_predictions_data$predictions_data <- NULL
-  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_no_predictions_data, data), "`model` must have `predictions_data` calculated")
+  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_no_predictions_data, data), "In `model` there should be the argument `predictions_data` <tibble> calculated")
 })
 
 test_that("Returns an error if the dependent variable in the logreg model formula does not exist in `data` or is not a survival class", {
@@ -120,9 +120,9 @@ test_that("Returns an error if the dependent variable in the logreg model formul
 
   model_logreg_bad_dependent_variable <- model_logreg
   model_logreg_bad_dependent_variable$formula <- y ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_dependent_variable, data), "the dependent variable must be of class `Surv`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_dependent_variable, data), "The dependent variable `y` must be <Surv>")
   model_logreg_bad_dependent_variable$formula <- no_exists ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_dependent_variable, data), "the dependent variable must be part of `data`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_dependent_variable, data), "The dependent variable `no_exists` must be part of `data`")
 })
 
 test_that("Returns an error if `intercept` does not exist or it is bad defined in the logreg model", {
@@ -132,9 +132,9 @@ test_that("Returns an error if `intercept` does not exist or it is bad defined i
 
   model_logreg_bad_intercept <- model_logreg
   model_logreg_bad_intercept$intercept <- NULL
-  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_intercept, data), "`intercept` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_intercept, data), "`intercept` must be <numeric>")
   model_logreg_bad_intercept$intercept <- "a"
-  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_intercept, data), "`intercept` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_1(model_logreg_bad_intercept, data), "`intercept` must be <numeric>")
 })
 
 test_that("Calculates the type 1 recalibrated predictions properly for logreg model", {

--- a/tests/testthat/test-calculate_predictions_recalibrated_type_2.R
+++ b/tests/testthat/test-calculate_predictions_recalibrated_type_2.R
@@ -23,7 +23,7 @@ test_that("Returns an error if `.imp` is not part of the `data` parameter", {
   model <- make_cox_model(environment()) |> calculate_predictions(data)
   data_no_imp <- data |> select(-.imp)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_imp), "must contain `.imp`")
+  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_imp), "The variable `.imp`")
 })
 
 test_that("Returns an error if `id` is not part of the `data` parameter", {
@@ -31,7 +31,7 @@ test_that("Returns an error if `id` is not part of the `data` parameter", {
   model <- make_cox_model(environment()) |> calculate_predictions(data)
   data_no_id <- data |> select(-id)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_id), "must contain `id`")
+  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_id), "The variable `id`")
 })
 
 test_that("Returns an error if `predictions_data` does not exist in cox `model`", {
@@ -41,7 +41,7 @@ test_that("Returns an error if `predictions_data` does not exist in cox `model`"
 
   model_cox_no_predictions_data <- model_cox
   model_cox_no_predictions_data$predictions_data <- NULL
-  expect_error(calculate_predictions_recalibrated_type_2(model_cox_no_predictions_data, data), "`model` must have `predictions_data` calculated")
+  expect_error(calculate_predictions_recalibrated_type_2(model_cox_no_predictions_data, data), "In `model` there should be the argument `predictions_data` <tibble> calculated")
 })
 
 test_that("Returns an error if the dependent variable in the cox model formula does not exist in `data` or is not a survival class", {
@@ -51,9 +51,9 @@ test_that("Returns an error if the dependent variable in the cox model formula d
 
   model_cox_bad_dependent_variable <- model_cox
   model_cox_bad_dependent_variable$formula <- y ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_dependent_variable, data), "the dependent variable must be of class `Surv`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_dependent_variable, data), "The dependent variable `y` must be <Surv>")
   model_cox_bad_dependent_variable$formula <- no_exists ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_dependent_variable, data), "the dependent variable must be part of `data`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_dependent_variable, data), "The dependent variable `no_exists` must be part of `data`")
 })
 
 test_that("Returns an error if `S0t` does not exist or it is bad defined in the cox model", {
@@ -63,9 +63,9 @@ test_that("Returns an error if `S0t` does not exist or it is bad defined in the 
 
   model_cox_bad_s0 <- model_cox
   model_cox_bad_s0$S0 <- NULL
-  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_s0, data), "`S0` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_s0, data), "`S0` must be <numeric>")
   model_cox_bad_s0$S0 <- "a"
-  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_s0, data), "`S0` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_cox_bad_s0, data), "`S0` must be <numeric>")
 })
 
 test_that("Calculates the type 2 recalibrated predictions properly for cox model", {
@@ -93,7 +93,7 @@ test_that("Returns an error if `.imp` is not part of the `data` parameter", {
   model <- make_logreg_model(environment()) |> calculate_predictions(data)
   data_no_imp <- data |> select(-.imp)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_imp), "must contain `.imp`")
+  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_imp), "The variable `.imp`")
 })
 
 test_that("Returns an error if `id` is not part of the `data` parameter", {
@@ -101,7 +101,7 @@ test_that("Returns an error if `id` is not part of the `data` parameter", {
   model <- make_logreg_model(environment()) |> calculate_predictions(data)
   data_no_id <- data |> select(-id)
 
-  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_id), "must contain `id`")
+  expect_error(model |> calculate_predictions_recalibrated_type_2(data_no_id), "The variable `id`")
 })
 
 test_that("Returns an error if `predictions_data` does not exist in logreg `model`", {
@@ -111,7 +111,7 @@ test_that("Returns an error if `predictions_data` does not exist in logreg `mode
 
   model_logreg_no_predictions_data <- model_logreg
   model_logreg_no_predictions_data$predictions_data <- NULL
-  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_no_predictions_data, data), "`model` must have `predictions_data` calculated")
+  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_no_predictions_data, data), "In `model` there should be the argument `predictions_data` <tibble> calculated")
 })
 
 test_that("Returns an error if the dependent variable in the logreg model formula does not exist in `data` or is not a survival class", {
@@ -121,9 +121,9 @@ test_that("Returns an error if the dependent variable in the logreg model formul
 
   model_logreg_bad_dependent_variable <- model_logreg
   model_logreg_bad_dependent_variable$formula <- y ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_dependent_variable, data), "the dependent variable must be of class `Surv`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_dependent_variable, data), "The dependent variable `y` must be <Surv>")
   model_logreg_bad_dependent_variable$formula <- no_exists ~ x + z
-  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_dependent_variable, data), "the dependent variable must be part of `data`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_dependent_variable, data), "The dependent variable `no_exists` must be part of `data`")
 })
 
 test_that("Returns an error if `intercept` does not exist or it is bad defined in the logreg model", {
@@ -133,9 +133,9 @@ test_that("Returns an error if `intercept` does not exist or it is bad defined i
 
   model_logreg_bad_intercept <- model_logreg
   model_logreg_bad_intercept$intercept <- NULL
-  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_intercept, data), "`intercept` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_intercept, data), "`intercept` must be <numeric>")
   model_logreg_bad_intercept$intercept <- "a"
-  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_intercept, data), "`intercept` must be a `numeric`")
+  expect_error(calculate_predictions_recalibrated_type_2(model_logreg_bad_intercept, data), "`intercept` must be <numeric>")
 })
 
 test_that("Calculates the type 2 recalibrated predictions properly for logreg model", {

--- a/tests/testthat/test-get_calibration_plot.R
+++ b/tests/testthat/test-get_calibration_plot.R
@@ -80,7 +80,7 @@ test_that("Returns an error when the formula is not properly defined in cox", {
       n_groups = 2,
       type = "predictions_aggregated"
     ),
-    "the dependent variable must be of class `Surv`"
+    "the dependent variable `y` must be <Surv>"
   )
   model_cox_bad_dependent_variable$formula <- no_exists ~ x + z
   expect_error(
@@ -90,7 +90,7 @@ test_that("Returns an error when the formula is not properly defined in cox", {
       n_groups = 2,
       type = "predictions_aggregated"
     ),
-    "the dependent variable must be part of `data`"
+    "the dependent variable `no_exists` must be part of `data`"
   )
 })
 
@@ -108,7 +108,7 @@ test_that("Returns an error when the formula is not properly defined in logreg",
       n_groups = 2,
       type = "predictions_aggregated"
     ),
-    "the dependent variable must be of class `Surv`"
+    "the dependent variable `y` must be <Surv>"
   )
   model_logreg_bad_dependent_variable$formula <- no_exists ~ x + z
   expect_error(
@@ -118,7 +118,7 @@ test_that("Returns an error when the formula is not properly defined in logreg",
       n_groups = 2,
       type = "predictions_aggregated"
     ),
-    "the dependent variable must be part of `data`"
+    "the dependent variable `no_exists` must be part of `data`"
   )
 })
 


### PR DESCRIPTION
To improve the package usability we have decided to change the error messages in some of the use cases. 

We have changed the `calculate_` function errors to improve the comprehension of the errors. 

* In errors where not all the variables were in the `model[["data"]]` argument the names of the variables are now displayed to the user to facilitate the error finding
* The classes of the variables are now displayed using the tag `{.cls }` of the `cli` package
* The logic for the error generation is extracted from some `calculate_` function to new not exported package functions. (`get_error_message_calculate_recalibrated` and `get_error_message_calculate`)
* The name of the dependent variable is also displayed in the errors

With all these changes we have the need to update all the tests that are relative to this error messages. Therefore they are also updated in this pull request.
